### PR TITLE
Refatora o método create_enum para evitar valores duplicados e melhor…

### DIFF
--- a/lib/salesforce/lead.rb
+++ b/lib/salesforce/lead.rb
@@ -277,12 +277,22 @@ module Salesforce
     #
     # @return [Hash] Um hash que representa a enumeração do picklist.
     def create_enum(picklistvalues)
-      picklist = { "enum" => [""], "default" => "", "showCustomVariables" => true }
-      picklistvalues.map do |value|
-        picklist["default"] = value["value"] if value["defaultValue"] == true
-        picklist["enum"].append(value["value"])
+      enum_values = [""]
+      default_value = ""
+
+      picklistvalues.each do |value|
+        enum_value = value["value"]
+        next if enum_value.blank? || enum_values.include?(enum_value)
+
+        enum_values << enum_value
+        default_value = enum_value if value["defaultValue"]
       end
-      picklist
+
+      {
+        "enum" => enum_values,
+        "default" => default_value,
+        "showCustomVariables" => true,
+      }
     end
   end
 end


### PR DESCRIPTION
This pull request refactors the `create_enum` method in `lib/salesforce/lead.rb` to improve clarity and ensure unique enum values are handled correctly.

Key changes:

* Refactored the `create_enum` method to replace the use of `map` with `each` for better readability and to explicitly handle cases where `enum_value` is blank or already included in the list. This ensures that duplicate or empty values are not added to the `enum` array.