### PR TITLE
[PRODUCTION]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ spec/config.yaml
 .rspec_status
 log/salesforce.log
 salesforce-*.gem
+node_modules/*
+*.json
+*.js

--- a/lib/salesforce/request.rb
+++ b/lib/salesforce/request.rb
@@ -41,7 +41,7 @@ module Salesforce
     # @raise [Salesforce::Error] Se a resposta não tiver um código de status 200 ou 201.
     def post(**kwargs)
       response = HTTParty.post(@url, headers: headers, body: kwargs[:payload]&.to_json)
-      @json = response
+      @json = response&.parsed_response&.presence || {}
       @status_code = response.code
       raise Salesforce::Error, handle_exception if @status_code != 201 && @status_code != 200
     end
@@ -51,7 +51,7 @@ module Salesforce
     # @raise [Salesforce::Error] Se a resposta não tiver um código de status 200.
     def get
       response = HTTParty.get(@url, headers: headers)
-      @json = response
+      @json = response&.parsed_response&.presence || {}
       @status_code = response.code
       raise Salesforce::Error, handle_exception if @status_code != 200
     end
@@ -61,7 +61,7 @@ module Salesforce
     # @raise [Salesforce::Error] Se a resposta não tiver um código de status 200 ou 201.
     def refresh
       response = HTTParty.post(@url, headers: headers_basic)
-      @json = response
+      @json = response&.parsed_response&.presence || {}
       @status_code = response.code
       raise Salesforce::Error, handle_exception if @status_code != 201 && @status_code != 200
     end
@@ -72,7 +72,7 @@ module Salesforce
     #
     # @return [String] A mensagem de erro extraída da resposta JSON.
     def handle_exception
-      exception_message = json.dig(0, "message") || json["error_description"] || json.to_s
+      exception_message = json.dig(0, "message") || json["error_description"] || json.to_s || "Unknown error"
       raise Salesforce::Error, exception_message
     end
 


### PR DESCRIPTION
This pull request improves the handling of HTTP responses in the `Salesforce::Request` class by ensuring that JSON parsing is more robust and that error messages are more informative. The changes focus on making the code safer when dealing with potentially empty or malformed responses from Salesforce.

**Improvements to response handling:**

* Updated the `post`, `get`, and `refresh` methods in `lib/salesforce/request.rb` to assign `@json` to the parsed response body if present, or to an empty hash if the response is empty or nil. This prevents errors when accessing response data. [[1]](diffhunk://#diff-56e5348243379e15f773d95fe122635ee9504f8d81cf22c50fbec6819297413aL44-R44) [[2]](diffhunk://#diff-56e5348243379e15f773d95fe122635ee9504f8d81cf22c50fbec6819297413aL54-R54) [[3]](diffhunk://#diff-56e5348243379e15f773d95fe122635ee9504f8d81cf22c50fbec6819297413aL64-R64)

**Error handling enhancements:**

* Modified the `handle_exception` method to ensure that an error message is always available, defaulting to `"Unknown error"` if other message fields are missing.